### PR TITLE
Fix typos

### DIFF
--- a/request.html
+++ b/request.html
@@ -502,7 +502,7 @@ function parseCSV(data) {
 <p>Mithril&#39;s <code>m.request</code> uses <code>XMLHttpRequest</code> instead of <code>fetch()</code> for a number of reasons:</p>
 <ul>
 <li><code>fetch</code> is not fully standardized yet, and may be subject to specification changes.</li>
-<li><code>XMLHttpRequest</code> calls can be aborted before they resolve (e.g. to avoid race conditions in for instant search UIs).</li>
+<li><code>XMLHttpRequest</code> calls can be aborted before they resolve (e.g. to avoid race conditions in for instance search UIs).</li>
 <li><code>XMLHttpRequest</code> provides hooks for progress listeners for long running requests (e.g. file uploads).</li>
 <li><code>XMLHttpRequest</code> is supported by all browsers, whereas <code>fetch()</code> is not supported by Internet Explorer, Safari and Android (non-Chromium).</li>
 </ul>

--- a/route.html
+++ b/route.html
@@ -422,7 +422,7 @@ m.route(document.body, &quot;/edit/1&quot;, {
 <p><code>m.route.set(m.route.get(), null, {state: {key: Date.now()}})</code></p>
 <h4 id="variadic-routes">Variadic routes</h4>
 <p>It&#39;s also possible to have variadic routes, i.e. a route with an argument that contains URL pathnames that contain slashes:</p>
-<pre><code class="lang-javascript">m.route(document.body, &quot;/edit/pictures/image.jpg&quot;, {
+<pre><code class="lang-javascript">m.route(document.body, &quot;/files/pictures/image.jpg&quot;, {
     &quot;/files/:file...&quot;: Edit,
 })
 </code></pre>


### PR DESCRIPTION
Note how the default route in the example didn't match the route ("/edit" vs "/files".)